### PR TITLE
updating deprecated version of supplying known locations to make.L

### DIFF
--- a/R/make.L.par.r
+++ b/R/make.L.par.r
@@ -28,37 +28,6 @@ make.L.par <- function(ras.list, iniloc, dateVec, known.locs = NULL, ncores = NU
   if (is.null(ncores)) ncores <- ceiling(parallel::detectCores() * .9)
   if (is.na(ncores) | ncores < 0) ncores <- ceiling(as.numeric(system('nproc', intern=T)) * .9)
   
-  if(!is.null(known.locs)){
-    print('Input known locations are being added to the likelihoods...')
-    # convert input date, lat, lon to likelihood surfaces with dim(L1)
-    L.locs <- L
-    
-    if (class(known.locs$date)[1] != class(dateVec)[1]) stop('dateVec and known.locs$date both need to be of class POSIXct.')
-    
-    known.locs <- known.locs[which(known.locs$date <= max(dateVec)),]
-    known.locs$dateVec <- findInterval(known.locs$date, dateVec)
-    
-    for(i in unique(known.locs$dateVec)){
-      known.locs.i <- known.locs[which(known.locs$dateVec == i),]
-      
-      if(length(known.locs.i[,1]) > 1){
-        # if multiple known locations are provided for a given day, only the first is used
-        warning(paste0('Multiple locations supplied at time step ', dateVec[i], '. Only the first one is being used.'))
-        known.locs.i <- known.locs.i[1,]
-      }
-      
-      ## erase other likelihood results for this day
-      L[[i]] <- L[[i]] * 0
-      
-      ## assign the known location for this day, i, as 1 (known) in likelihood raster
-      L.locs[[i]][raster::cellFromXY(L.locs[[i]], known.locs.i[,c('lon','lat')])] <- 1
-      
-    }
-    
-    ## add the locs layer to the raster list
-    ras.list[[length(ras.list) + 1]] <- L.locs
-  }
-  
   # BEGIN PARALLEL STUFF  
   
   # ncores = detectCores()  # should be an input argument
@@ -149,6 +118,34 @@ make.L.par <- function(ras.list, iniloc, dateVec, known.locs = NULL, ncores = NU
       L[[i]] <- L[[i]] * 0
       
       # assign the known location for this day, i, as 1 (known) in likelihood raster
+      L[[i]][raster::cellFromXY(L[[i]], known.locs.i[,c('lon','lat')])] <- 1
+      
+    }
+    
+  }
+  
+  ## ADD KNOWN LOCATIONS
+  if(!is.null(known.locs)){
+    print('Known locations are being added to the likelihoods...')
+    
+    if (class(known.locs$date)[1] != class(dateVec)[1]) stop('dateVec and known.locs$date both need to be of class POSIXct.')
+    
+    known.locs <- known.locs[which(known.locs$date <= max(dateVec)),]
+    known.locs$dateVec <- findInterval(known.locs$date, dateVec)
+    
+    for(i in unique(known.locs$dateVec)){
+      known.locs.i <- known.locs[which(known.locs$dateVec == i),]
+      
+      if(length(known.locs.i[,1]) > 1){
+        # if multiple known locations are provided for a given day, only the first is used
+        warning(paste0('Multiple locations supplied at time step ', dateVec[i], '. Only the first one is being used.'))
+        known.locs.i <- known.locs.i[1,]
+      }
+      
+      ## erase other likelihood results for this day
+      L[[i]] <- L[[i]] * 0
+      
+      ## assign the known location for this day, i, as 1 (known) in likelihood raster
       L[[i]][raster::cellFromXY(L[[i]], known.locs.i[,c('lon','lat')])] <- 1
       
     }


### PR DESCRIPTION
@marosteg identified this issue with known locations in `make.L` (#40). Should be fixed now but please test both `make.L()` and `make.L.par()`.