### PR TITLE
Sst aggregation issue

### DIFF
--- a/R/calc.bathy.par.r
+++ b/R/calc.bathy.par.r
@@ -30,6 +30,7 @@ calc.bathy.par <- function(mmd, bathy.grid, dateVec, focalDim = NULL, sens.err =
     bathy.grid[bathy.grid < 0] <- NA
   }
   
+  if (class(mmd$Date)[1] != class(dateVec)[1]) stop('dateVec and mmd$Date both need to be of class POSIXct.')
   mmd <- mmd[which(mmd$Date <= max(dateVec)),]
   mmd$dateVec <- findInterval(mmd$Date, dateVec)
   mmd <- data.frame(mmd %>% group_by(dateVec) %>% 

--- a/R/calc.bathy.r
+++ b/R/calc.bathy.r
@@ -29,6 +29,7 @@ calc.bathy <- function(mmd, bathy.grid, dateVec, focalDim = NULL, sens.err = 5, 
     bathy.grid[bathy.grid < 0] <- NA
   }
   
+  if (class(mmd$Date)[1] != class(dateVec)[1]) stop('dateVec and mmd$Date both need to be of class POSIXct.')
   mmd <- mmd[which(mmd$Date <= max(dateVec)),]
   mmd$dateVec <- findInterval(mmd$Date, dateVec)
   mmd <- data.frame(mmd %>% group_by(dateVec) %>% 

--- a/R/calc.ohc.par.r
+++ b/R/calc.ohc.par.r
@@ -121,7 +121,7 @@ calc.ohc.par <- function(pdt, filename, isotherm = '', ohc.dir, dateVec, bathy =
   cl = parallel::makeCluster(ncores)
   doParallel::registerDoParallel(cl, cores = ncores)
   
-  ans = foreach::foreach(i = 1:T) %dopar%{
+  ans = foreach::foreach(i = 1:T, .export = 'likint3') %dopar%{
     
     pdt.i <- pdt[which(pdt$dateVec == i),]
     if (nrow(pdt.i) == 0) return(NA)

--- a/R/calc.sst.r
+++ b/R/calc.sst.r
@@ -41,7 +41,7 @@ calc.sst <- function(tag.sst, filename, sst.dir, dateVec, focalDim = NULL, sens.
   T <- length(dateVec)
   
   ## setup
-  nc1 <- RNetCDF::open.nc(dir(sst.dir, full.names = T)[1])
+  nc1 <- RNetCDF::open.nc(paste(sst.dir, filename, '_', as.Date(dateVec[tag.sst$dateVec[1]]), '.nc', sep=''))
   ncnames = NULL
   nmax <- RNetCDF::file.inq.nc(nc1)$nvars - 1
   for(ii in 0:nmax) ncnames[ii + 1] <- RNetCDF::var.inq.nc(nc1, ii)$name


### PR DESCRIPTION
Identified bug in `calc.sst.par()` that was due to auto aggregation occuring on MUR data but that aggregation was not reflected in the attempted calculation of the output likelihoods causing a dim mismatch.