### PR TITLE
add error for date class mismatch

### DIFF
--- a/R/calc.bathy.par.r
+++ b/R/calc.bathy.par.r
@@ -30,6 +30,7 @@ calc.bathy.par <- function(mmd, bathy.grid, dateVec, focalDim = NULL, sens.err =
     bathy.grid[bathy.grid < 0] <- NA
   }
   
+  if (class(mmd$Date)[1] != class(dateVec)[1]) stop('dateVec and mmd$Date both need to be of class POSIXct.')
   mmd <- mmd[which(mmd$Date <= max(dateVec)),]
   mmd$dateVec <- findInterval(mmd$Date, dateVec)
   mmd <- data.frame(mmd %>% group_by(dateVec) %>% 

--- a/R/calc.bathy.r
+++ b/R/calc.bathy.r
@@ -29,6 +29,7 @@ calc.bathy <- function(mmd, bathy.grid, dateVec, focalDim = NULL, sens.err = 5, 
     bathy.grid[bathy.grid < 0] <- NA
   }
   
+  if (class(mmd$Date)[1] != class(dateVec)[1]) stop('dateVec and mmd$Date both need to be of class POSIXct.')
   mmd <- mmd[which(mmd$Date <= max(dateVec)),]
   mmd$dateVec <- findInterval(mmd$Date, dateVec)
   mmd <- data.frame(mmd %>% group_by(dateVec) %>% 


### PR DESCRIPTION
Previously there was no check to ensure the input data and `dateVec` both had dates of class `POSIXt`