### PR TITLE
add .export for likint3 to parallel calcs

### DIFF
--- a/R/calc.bathy.par.r
+++ b/R/calc.bathy.par.r
@@ -66,7 +66,7 @@ calc.bathy.par <- function(mmd, bathy.grid, dateVec, focalDim = NULL, sens.err =
   cl = parallel::makeCluster(ncores)
   doParallel::registerDoParallel(cl, cores = ncores)
   
-  ans = foreach::foreach(i = 1:T, .packages = c('raster')) %dopar%{
+  ans = foreach::foreach(i = 1:T, .export = 'likint3', .packages = c('raster')) %dopar%{
     
     #print(dateVec[i])
     

--- a/R/calc.hycom.par.r
+++ b/R/calc.hycom.par.r
@@ -110,26 +110,8 @@ calc.hycom.par <- function(pdt, filename, hycom.dir, focalDim = 9, dateVec, use.
   
   print(paste0('Processing in parallel using ', ncores, ' cores... '))
   
-  ans = foreach::foreach(i = 1:T) %dopar%{
+  ans = foreach::foreach(i = 1:T, .export = 'likint3', .packages = c('raster')) %dopar%{
     
-    #print(dateVec[i])
-    likint3 <- function(w, wsd, minT, maxT){
-      #lwr <- minT - .75 * (maxT - minT)
-      #upr <- maxT + .75 * (maxT - minT)
-      #widx = w >= minT-1 & w <= maxT+1 & !is.na(w)
-      #widx = w >= minT-1 & w <= maxT+1 & 
-      widx <- !is.na(w)
-      wdf = data.frame(w = as.vector(w[widx]), wsd = as.vector(wsd[widx]))
-      wdf$wsd[is.na(wdf$wsd)] = 1e-3
-      # wint = apply(wdf, 1, function(x) pracma::integral(dnorm, minT, maxT, mean = x[1], sd = x[2]))
-      wint = apply(wdf, 1, function(x) stats::integrate(stats::dnorm, 
-                                                        # !!!!!! *2 ????
-                                                        # minT, maxT, mean = x[1], sd = x[2]*2 )$value)
-                                                        minT, maxT, mean = x[1], sd = x[2])$value)
-      w = w * 0
-      w[widx] = wint
-      w
-    }
     pdt.i <- pdt[which(pdt$dateVec == i),]
     if (nrow(pdt.i) == 0) return(NA)
     

--- a/R/calc.ohc.par.r
+++ b/R/calc.ohc.par.r
@@ -121,7 +121,7 @@ calc.ohc.par <- function(pdt, filename, isotherm = '', ohc.dir, dateVec, bathy =
   cl = parallel::makeCluster(ncores)
   doParallel::registerDoParallel(cl, cores = ncores)
   
-  ans = foreach::foreach(i = 1:T, .export = 'likint3') %dopar%{
+  ans = foreach::foreach(i = 1:T, .export = 'likint3', .packages = c('raster')) %dopar%{
     
     pdt.i <- pdt[which(pdt$dateVec == i),]
     if (nrow(pdt.i) == 0) return(NA)

--- a/R/calc.sst.par.r
+++ b/R/calc.sst.par.r
@@ -96,7 +96,7 @@ calc.sst.par <- function(tag.sst, filename, sst.dir, dateVec, focalDim = NULL, s
   cl = parallel::makeCluster(ncores)
   doParallel::registerDoParallel(cl, cores = ncores)
   
-  ans = foreach::foreach(i = 1:T, .packages = c('raster')) %dopar%{
+  ans = foreach::foreach(i = 1:T, .export = 'likint3', .packages = c('raster')) %dopar%{
       
     tag.sst.i <- tag.sst[which(tag.sst$dateVec == i),]
     if (nrow(tag.sst.i) == 0) return(NA)
@@ -125,7 +125,7 @@ calc.sst.par <- function(tag.sst, filename, sst.dir, dateVec, focalDim = NULL, s
     dat <- base::t(raster::as.matrix(raster::flip(r, 2)))
     
     # compare sst to that day's tag-based ohc
-    lik.sst <- HMMoce:::likint3(dat, sdx, sst.i[1], sst.i[2])
+    lik.sst <- likint3(dat, sdx, sst.i[1], sst.i[2])
     
     lik.sst 
     


### PR DESCRIPTION
Standardize the explicit `.export` of `likint3` in all `dopar` loops.